### PR TITLE
change README to mention the proper env variable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 A universal javascript client that talks to a [living room server](https://github.com/jedahan/living-room-server)
 
-It works in node or the browser, make sure you have a server listening on localhost:3000 or change LIVING_ROOM_URI to point to your server
+It works in node or the browser, and listens to server at the environment variable ROOMDB_URI or the default value of `http://localhost:3000`
 
 # commandline app
 


### PR DESCRIPTION
Looks like the code looks at `ROOMDB_URI`, so let’s have the README reflect this.

Or do you want to change the prefix to be `LIVING_ROOM_*` instead of `ROOMDB_*`?