### PR TITLE
code to implement `$a sees $b`

### DIFF
--- a/examples/animals/sees.js
+++ b/examples/animals/sees.js
@@ -1,0 +1,112 @@
+const Room = require("../build/room.js");
+const room = new Room();
+
+const SEES_DIST = 0.5;
+
+const seesAnimal = () => {
+  // Animal looks like:
+  //
+  // {
+  //   name: { word: 'Simba' },
+  //   type: foo,
+  //   x: 0.123,
+  //   y: 0.456
+  // }
+
+  Promise.all([
+    _promiseSelect(`$a sees $b`),
+    _promiseSelect(`$name is a $type animal at ($x, $y)`)
+  ])
+    .then(([oldSees, animals]) => {
+      // console.log("oldSees?", oldSees);
+      // console.log("animals?", animals);
+
+      oldSees = oldSees.map(x => _joinNames([x.a.word, x.b.word]));
+      let newSees = _getSees(animals).map(_joinNames);
+
+      oldSees = new Set(oldSees);
+      newSees = new Set(newSees);
+
+      // get and remove intersection between the two
+      let intersection = [];
+      newSees.forEach(x => {
+        if (oldSees.has(x)) {
+          intersection.push(x);
+        }
+      });
+      intersection.forEach(x => {
+        oldSees.delete(x);
+        newSees.delete(x);
+      });
+
+      // console.log("processed oldSees", oldSees);
+      // console.log("processed newSees", newSees);
+
+      // retract remaining olds and assert remaining news (no change to intersection)
+      Array.from(oldSees)
+        .map(_splitNames)
+        .forEach(([a, b]) => {
+          console.log(`RETRACT ${a} sees ${b}`);
+          room.retract(`${a} sees ${b}`);
+        });
+      Array.from(newSees)
+        .map(_splitNames)
+        .forEach(([a, b]) => {
+          console.log(`ASSERT ${a} sees ${b}`);
+          room.assert(`${a} sees ${b}`);
+        });
+    })
+    .catch(e => {
+      console.log("ERROR", e);
+    });
+};
+
+// helpers
+
+const _promiseSelect = query =>
+  new Promise((resolve, reject) => room.select(query).doAll(resolve));
+
+const _getSees = animals => {
+  // group by name (in case of redundant names)
+  let nameToAnimalsMap = new Map();
+
+  animals.forEach(x => {
+    let name = x.name.word;
+    if (!nameToAnimalsMap.has(name)) {
+      nameToAnimalsMap.set(name, []);
+    }
+    nameToAnimalsMap.get(name).push(x);
+  });
+
+  let seenNames = new Set();
+  let results = [];
+
+  // iterate over names finding in range and trying to avoid duplicate work
+  nameToAnimalsMap.forEach((anims, name) => {
+    anims.forEach(anim => {
+      let name = anim.name.word;
+      let sees = animals.filter(
+        o =>
+          o.name.word !== name &&
+          !seenNames.has(o.name.word) &&
+          _distance(anim, o) <= SEES_DIST
+      );
+
+      seenNames.add(name);
+
+      sees.forEach(s => {
+        results.push([name, s.name.word], [s.name.word, name]);
+      });
+    });
+  });
+
+  return results;
+};
+
+const _distance = (a, b) =>
+  Math.sqrt(Math.pow(a.x - b.x, 2) + Math.pow(a.y - b.y, 2));
+
+const _joinNames = x => x.join("$");
+const _splitNames = x => x.split("$");
+
+setInterval(seesAnimal, 500);


### PR DESCRIPTION
This adds logic for "$a sees $b".

It:

1. selects old sees and current animals
2. retracts old sees that no longer match
3. asserts new sees (no change to ones that haven't changed)

Because a name can exist multiple times, it considers all copies of a name as one thing and groups them to check them together.

Needs some testing to verify my comparing logic is OK. Can also play with SEES_DIST and other stuff to make it work more interestingly.